### PR TITLE
🚀 Fix: Popup Buttons Not Working in Manifest V3

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -1,0 +1,20 @@
+// Always use the full, absolute URL for extension assets:
+const newTabUrl = chrome.runtime.getURL('newtab.html');
+
+document.getElementById('new-tab').addEventListener('click', () => {
+  // If you omit `url`, this will open your overridden New Tab:
+  // chrome.tabs.create({});
+  chrome.tabs.create({ url: newTabUrl });
+});
+
+document.getElementById('settings').addEventListener('click', () => {
+  chrome.tabs.create({ url: newTabUrl }, (tab) => {
+    setTimeout(() => {
+      chrome.tabs.sendMessage(tab.id, { action: 'openSettings' });
+    }, 500);
+  });
+});
+
+document.getElementById('feedback').addEventListener('click', () => {
+  chrome.tabs.create({ url: 'https://github.com/Himanshu500/Chrome-Theam-Extension/issues' });
+});

--- a/popup.html
+++ b/popup.html
@@ -39,6 +39,7 @@
       border-radius: 6px;
       margin-bottom: 8px;
       transition: all 0.2s ease;
+      user-select: none;
     }
     
     .menu-item:hover {
@@ -89,23 +90,6 @@
   
   <div class="version">Version 1.0</div>
   
-  <script>
-    document.getElementById('new-tab').addEventListener('click', () => {
-      chrome.tabs.create({ url: 'newtab.html' });
-    });
-    
-    document.getElementById('settings').addEventListener('click', () => {
-      chrome.tabs.create({ url: 'newtab.html' }, (tab) => {
-        // Send message to open settings
-        setTimeout(() => {
-          chrome.tabs.sendMessage(tab.id, { action: 'openSettings' });
-        }, 500);
-      });
-    });
-    
-    document.getElementById('feedback').addEventListener('click', () => {
-      chrome.tabs.create({ url: 'https://github.com/yourusername/hackerspace/issues' });
-    });
-  </script>
+  <script src="js/popup.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
# 🚀 Fix: Popup Buttons Not Working in Manifest V3

## 🧠 Summary

This PR fixes the issue where popup buttons (e.g., "New HackerSpace Tab") were unresponsive in the Chrome extension. The root cause was due to **inline scripts being blocked by Manifest V3's Content Security Policy (CSP)**.

### ✅ What's fixed:

- Moved all inline JavaScript from `popup.html` to a new `popup.js` file